### PR TITLE
Fixed version conflict with dart 2.1.0/flutter 0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dev_dependencies:
   test: ^0.12.0
-  coverage: "^0.9.3"
+  coverage: "^0.12.2"
   dart_codecov_generator:
     git:
       url: "https://github.com/wendux/dart-codecov.git"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutterchina/cookie_jar
 author: wendux <824783146@qq.com>, long1eu<home@long1.eu>
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: '>=2.0.0-dev.68.0 <3.0.0'
 
 #dependencies:
 #  path: ^1.4.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutterchina/cookie_jar
 author: wendux <824783146@qq.com>, long1eu<home@long1.eu>
 
 environment:
-  sdk: '>=2.0.0-dev.68.0 <3.0.0'
+  sdk: '>=2.0.0-dev.58.0 <3.0.0'
 
 #dependencies:
 #  path: ^1.4.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutterchina/cookie_jar
 author: wendux <824783146@qq.com>, long1eu<home@long1.eu>
 
 environment:
-  sdk: '>=1.20.1 <4.0.0'
+  sdk: ">=2.0.0-dev.68.0 <3.0.0"
 
 #dependencies:
 #  path: ^1.4.1


### PR DESCRIPTION
Check https://github.com/flutter/flutter/issues/20700 for more info.

Issue is resolved by just setting a minimum environment version for the
plugin.

We need to wait before https://github.com/wendux/dart-codecov/pull/1 closes then it closes:
https://github.com/flutterchina/cookie_jar/issues/3