### PR TITLE
Add force init function to reload cached cookies.

### DIFF
--- a/lib/src/persist_cookie_jar.dart
+++ b/lib/src/persist_cookie_jar.dart
@@ -45,6 +45,11 @@ class PersistCookieJar extends DefaultCookieJar {
   List<Map<String, Map<String, Map<String, SerializableCookie>>>> get domains =>
       _dirInit[_dir];
 
+  void forceInit() {
+    _dirInit[_dir] = null;
+    _checkInited();
+  }
+
   void _checkInited(){
     if (_dirInit[_dir] == null) {
       _dirInit[_dir] = [


### PR DESCRIPTION
This is a resolution of issue https://github.com/flutterchina/cookie_jar/issues/14 that cannot refresh cookie after changing in another task.


