### PR TITLE
test: DefaultCookieJar stores cookies isolated

### DIFF
--- a/test/cookie_jar_test.dart
+++ b/test/cookie_jar_test.dart
@@ -170,4 +170,17 @@ void main() async {
       expect(results.length, 0);
     });
   });
+
+  test('DefaultCookieJar stores cookies isolated', () async {
+    final uri = Uri.parse('https://www.baidu.com/xx');
+
+    final cj = DefaultCookieJar();
+    await cj.saveFromResponse(uri, cookies);
+    final results = await cj.loadForRequest(uri);
+    expect(results, isNotEmpty);
+
+    final otherCj = DefaultCookieJar();
+    final otherResults = await otherCj.loadForRequest(uri);
+    expect(otherResults, isEmpty);
+  });
 }


### PR DESCRIPTION
Added test for #22 (fixed [here](https://github.com/flutterchina/cookie_jar/commit/f8ca9c477b92263e4e4eb0617205f4c5efee62cc#diff-af68040730ee70be7e2ee68ed7864a336436db0c244456e3f317d8fd57240295L20))