### PR TITLE
Fix runtype cast exception.

### DIFF
--- a/lib/src/persist_cookie_jar.dart
+++ b/lib/src/persist_cookie_jar.dart
@@ -52,7 +52,9 @@ class PersistCookieJar extends DefaultCookieJar {
         final Map<String, dynamic> jsonData = json.decode(str);
         final Map<String, Map<String, Map<String, SerializableCookie>>>
             cookies = jsonData.map((domain, cookies) {
-          final domainCookies = cookies.cast<String, dynamic>().map(
+          final domainCookies = cookies
+              .cast<String, dynamic>()
+              .map<String, Map<String, SerializableCookie>>(
             (path, map) {
               final cookieForPath = map.cast<String, String>();
               final realCookies =
@@ -60,12 +62,15 @@ class PersistCookieJar extends DefaultCookieJar {
                 String cookieName,
                 String cookie,
               ) {
-                return MapEntry(
+                return MapEntry<String, SerializableCookie>(
                   cookieName,
                   SerializableCookie.fromJson(cookie),
                 );
               });
-              return MapEntry(path, realCookies);
+              return MapEntry<String, Map<String, SerializableCookie>>(
+                path,
+                realCookies,
+              );
             },
           );
           return MapEntry<String, Map<String, Map<String, SerializableCookie>>>(


### PR DESCRIPTION
Fixes an error during the initialisation:

> _column: 13
> _line: 73
> _message: "type '_Map<dynamic, dynamic>' is not a subtype of type 'Map<String, Map<String, SerializableCookie>>'"
> _stackTrace: 
> PersistCookieJar._checkInitialized.<anonymous closure> (package:cookie_jar/src/persist_cookie_jar.dart:73:13)
> PersistCookieJar._checkInitialized (package:cookie_jar/src/persist_cookie_jar.dart:54:32)
> PersistCookieJar.loadForRequest (package:cookie_jar/src/persist_cookie_jar.dart:99:5)
> _url: "package:cookie_jar/src/persist_cookie_jar.dart"