### PR TITLE
Simply replace `\` to `/` rather than using `Uri` when parsing a storage base directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 4.0.8
+
+- Simply replace `\` to `/` rather than using `Uri` when parsing a storage base directory.
+
 ## 4.0.7
 
 - Allow to configure whether to delete host cookies when load failed.

--- a/lib/src/jar/default.dart
+++ b/lib/src/jar/default.dart
@@ -34,7 +34,7 @@ class DefaultCookieJar implements CookieJar {
                       >>>> _cookies =
       <Map<String, Map<String, Map<String, SerializableCookie>>>>[
     <String, Map<String, Map<String, SerializableCookie>>>{},
-    <String, Map<String, Map<String, SerializableCookie>>>{}
+    <String, Map<String, Map<String, SerializableCookie>>>{},
   ];
 
   Map<String, Map<String, Map<String, SerializableCookie>>> get domainCookies =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cookie_jar
 description: A cookie manager for http requests in Dart, help you to deal with the cookie policies and persistence.
-version: 4.0.7
+version: 4.0.8
 repository: https://github.com/flutterchina/cookie_jar
 issue_tracker: https://github.com/flutterchina/cookie_jar/issues
 

--- a/test/cookie_jar_test.dart
+++ b/test/cookie_jar_test.dart
@@ -275,22 +275,23 @@ void main() async {
 
   group('FileStorage', () {
     test('Parsed directory correctly', () async {
-      final s1 = FileStorage('./test/cookies');
-      final s2 = FileStorage('./test/cookies/');
-      final s3 = FileStorage('/test/cookies');
-      final s4 = FileStorage('/test/cookies/');
-      // Silence s3 and s4 because those directories
-      // won't have permission to create.
+      final s1 = FileStorage.test('./test/cookies');
+      final s2 = FileStorage.test('./test/cookies/');
+      final s3 = FileStorage.test('/test/cookies');
+      final s4 = FileStorage.test('/test/cookies/');
+      final s5 = FileStorage.test('C:\\.cookies');
       await Future.wait([
         s1.init(true, false),
         s2.init(true, false),
-        s3.init(true, false).catchError((_) {}),
-        s4.init(true, false).catchError((_) {}),
+        s3.init(true, false),
+        s4.init(true, false),
+        s5.init(true, false),
       ]);
-      expect(s1.currentDirectory, 'test/cookies/ie0_ps1/');
-      expect(s2.currentDirectory, 'test/cookies/ie0_ps1/');
+      expect(s1.currentDirectory, './test/cookies/ie0_ps1/');
+      expect(s2.currentDirectory, './test/cookies/ie0_ps1/');
       expect(s3.currentDirectory, '/test/cookies/ie0_ps1/');
       expect(s4.currentDirectory, '/test/cookies/ie0_ps1/');
+      expect(s5.currentDirectory, 'C:/.cookies/ie0_ps1/');
     });
   });
 }


### PR DESCRIPTION
Resolves #52.